### PR TITLE
Simplify response caching

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -17,14 +17,6 @@ class Account extends ApiResource
     private $plan;
 
     /**
-     * Inialises a new instance of the Account object
-     */
-    public function __construct($config)
-    {
-        $this->apiInit($config);
-    }
-
-    /**
      * Retrieve the account & plan information
      */
     public function get()

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -68,8 +68,9 @@ class ApiResource
         // Make the request and save the last response
         $this->lastResponse = $apiRequestor->request($endpoint, $method, $params, $getFileContent, $filename);
 
-        // Store the last response in the ZamzarClient (use $this->config instead of $this->getConfig() because we are passing values by reference)
-        core::zamzarClientSetLastResponse($this->config, $this->lastResponse);
+        if (isset($this->config['client'])) {
+            ($this->config['client'])->setLastResponse($this->lastResponse);
+        }
 
         // Store the paging information
         $this->paging = $this->lastResponse->getPaging();
@@ -134,6 +135,16 @@ class ApiResource
     public function getLastResponse()
     {
         return $this->lastResponse;
+    }
+
+    public function hasLastResponse()
+    {
+        return !is_null($this->getLastResponse());
+    }
+
+    protected function setLastResponse($response)
+    {
+        $this->lastResponse = $response;
     }
 
     /**

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -39,15 +39,12 @@ class ApiResource
      * Should be called from an object's constructor
      * $config will contain an apikey or a config array and optionally an objectid (a job id, a file id, a format name etc)
      */
-    protected function apiInit($config, $objectId = '')
+    public function __construct($config, $objectId = '')
     {
-        // Check/Set Config Array
         $this->setConfig($config);
 
-        // Set Endpoint for this object
         $this->setEndPoint($objectId);
 
-        // Log this class and object id
         $class = str_replace("Zamzar\\", "", static::class);
         if ($objectId == '') {
             Logger::log($this->config, 'CreateObj=>' . $class . get_parent_class());

--- a/lib/File.php
+++ b/lib/File.php
@@ -24,7 +24,7 @@ class File extends ApiResource
      */
     public function __construct($config, $data)
     {
-        $this->apiInit($config, $data->id);
+        parent::__construct($config, $data->id);
         $this->setValues($data);
     }
 

--- a/lib/Files.php
+++ b/lib/Files.php
@@ -13,12 +13,4 @@ class Files extends ApiResource
     use \Zamzar\ApiOperations\All;
     use \Zamzar\ApiOperations\Get;
     use \Zamzar\ApiOperations\Upload;
-
-    /**
-     * Inialises a new instance of the Files object
-     */
-    public function __construct($config)
-    {
-        $this->apiInit($config);
-    }
 }

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -18,7 +18,7 @@ class Format extends ApiResource
      */
     public function __construct($config, $data)
     {
-        $this->apiInit($config, $data->name);
+        parent::__construct($config, $data->name);
         $this->setValues($data);
     }
 

--- a/lib/Formats.php
+++ b/lib/Formats.php
@@ -11,12 +11,4 @@ class Formats extends ApiResource
     use \Zamzar\ApiOperations\Paging;
     use \Zamzar\ApiOperations\All;
     use \Zamzar\ApiOperations\Get;
-
-    /**
-     * Inialises a new instance of the Formats class
-     */
-    public function __construct($config)
-    {
-        $this->apiInit($config);
-    }
 }

--- a/lib/Import.php
+++ b/lib/Import.php
@@ -31,7 +31,7 @@ class Import extends ApiResource
      */
     public function __construct($config, $data)
     {
-        $this->apiInit($config, $data->id);
+        parent::__construct($config, $data->id);
         $this->setValues($data);
     }
 

--- a/lib/Imports.php
+++ b/lib/Imports.php
@@ -12,12 +12,4 @@ class Imports extends ApiResource
     use \Zamzar\ApiOperations\All;
     use \Zamzar\ApiOperations\Get;
     use \Zamzar\ApiOperations\Start;
-
-    /**
-     * Inialises a new instance of the Imports Class
-     */
-    public function __construct($config)
-    {
-        $this->apiInit($config);
-    }
 }

--- a/lib/Job.php
+++ b/lib/Job.php
@@ -39,7 +39,7 @@ class Job extends ApiResource
      */
     public function __construct($config, $data)
     {
-        $this->apiInit($config, $data->id);
+        parent::__construct($config, $data->id);
         $this->setValues($data);
     }
 

--- a/lib/Jobs.php
+++ b/lib/Jobs.php
@@ -12,12 +12,4 @@ class Jobs extends ApiResource
     use \Zamzar\ApiOperations\All;
     use \Zamzar\ApiOperations\Get;
     use \Zamzar\ApiOperations\Submit;
-
-    /**
-     * Inialises a new instance of the Jobs object
-     */
-    public function __construct($config)
-    {
-        $this->apiInit($config);
-    }
 }

--- a/lib/Util/Core.php
+++ b/lib/Util/Core.php
@@ -81,30 +81,6 @@ class Core
     }
 
     /**
-     * Set the last response returned from api
-     * Note that this is done by reference and stored within ZamzarClient if instantiated
-     */
-    public static function zamzarClientSetLastResponse(&$config, $lastResponse)
-    {
-        if (array_key_exists("zamzar_client_last_response", $config)) {
-            $zamzarClientLastResponse = &$config['zamzar_client_last_response'];
-            $zamzarClientLastResponse = $lastResponse;
-        }
-    }
-
-    /**
-     * Get the last response returned from api
-     * Note that this done by reference to the the ZamzarClient if instantiated
-     */
-    public static function zamzarClientGetLastResponse(&$config)
-    {
-        if (array_key_exists("zamzar_client_last_response", $config)) {
-            $lastResponse = &$config['zamzar_client_last_response'];
-            return $lastResponse;
-        }
-    }
-
-    /**
      * Get the Default Config Array
      */
     private static function getDefaultConfig()

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -41,15 +41,9 @@ class ZamzarClient extends ApiResource
      */
     public function __construct($config)
     {
-        if (is_string($config)) {
-            $config = [
-                'api_key' => $config,
-            ];
-        }
-
-        $config['client'] = $this;
-
         parent::__construct($config);
+
+        $this->config['client'] = $this;
     }
 
     /**

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -49,7 +49,7 @@ class ZamzarClient extends ApiResource
 
         $config['client'] = $this;
 
-        $this->apiInit($config);
+        parent::__construct($config);
     }
 
     /**

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -37,27 +37,18 @@ class ZamzarClient extends ApiResource
     private $jobs;
 
     /**
-     * Reference Pointers
-     * Read/Write from Util/Core and Util/Logger only, do not implement any direct access to these variables.
-     */
-    private $zamzarClientLastResponse;
-
-    /**
      * Initialises a new instance of the Zamzar class
      */
     public function __construct($config)
     {
-        // Convert to an array if a string is provided
-        if (\is_string($config)) {
+        if (is_string($config)) {
             $config = [
                 'api_key' => $config,
             ];
         }
 
-        // Set Reference Pointer to Last Response
-        $config['zamzar_client_last_response'] = &$this->zamzarClientLastResponse;
+        $config['client'] = $this;
 
-        // Initialise
         $this->apiInit($config);
     }
 
@@ -87,23 +78,6 @@ class ZamzarClient extends ApiResource
         $apiResponse = $this->apiRequest($this->getEndpoint());
         $data = $apiResponse->getBody();
         return $data->message;
-    }
-
-    /**
-     * HasLastResponse
-     */
-    public function hasLastResponse()
-    {
-        return !is_null($this->getLastResponse());
-    }
-
-    /**
-     * GetLastResponse (overrides inherited version)
-     */
-    public function getLastResponse()
-    {
-        $config = $this->getConfig();
-        return core::zamzarClientGetLastResponse($config);
     }
 
     /**


### PR DESCRIPTION
Simplifies how the last response is cached in `ZamzarClient`:

* `ZamzarClient` now passes itself into subclasses (e.g. `Jobs`), via the config array (`$config['client']`).
* Removes the special-case `$zamzarClientLastResponse` from `ZamzarClient`, and just uses the base `ApiResource::$lastResponse`.
* Simplifies object initialisation.

All tests are passing.