### PR TITLE
Reduce Logging noise

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-          "Zamzar\\": "tests/"
+          "Tests\\": "tests/"
         }
     }
 }

--- a/init.php
+++ b/init.php
@@ -4,7 +4,7 @@
 require __DIR__ . '/lib/Util/Core.php';
 require __DIR__ . '/lib/Util/LoggerInterface.php';
 require __DIR__ . '/lib/Util/DefaultLogger.php';
-require __DIR__ . '/lib/Util/Logger.php';
+require __DIR__ . '/lib/Zamzar.php';
 
 // HTTPClient
 require __DIR__ . '/lib/HttpClient/GuzzleClient.php';

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -2,9 +2,7 @@
 
 namespace Zamzar;
 
-use Zamzar\Exception;
 use Zamzar\HttpClient\GuzzleClient;
-use Zamzar\Util\Logger;
 
 /**
  * ApiRequestor Class
@@ -40,7 +38,7 @@ class ApiRequestor
     public function request($endpoint, $method = 'GET', $params = [], $getFileContent = false, $filename = '')
     {
         // Capture some log information in the ZamzarClient
-        Logger::getLogger()->info('(' . $method . ') ' . $endpoint . ' params=' . json_encode($params));
+        Zamzar::getLogger()->info('(' . $method . ') ' . $endpoint . ' params=' . json_encode($params));
 
         // Store local values
         $this->endpoint = $endpoint;

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -40,7 +40,7 @@ class ApiRequestor
     public function request($endpoint, $method = 'GET', $params = [], $getFileContent = false, $filename = '')
     {
         // Capture some log information in the ZamzarClient
-        Logger::log($this->config, '(' . $method . ') ' . $endpoint . ' params=' . json_encode($params));
+        Logger::getLogger()->info('(' . $method . ') ' . $endpoint . ' params=' . json_encode($params));
 
         // Store local values
         $this->endpoint = $endpoint;

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -37,10 +37,10 @@ class ApiRequestor
      */
     public function request($endpoint, $method = 'GET', $params = [], $getFileContent = false, $filename = '')
     {
-        // Capture some log information in the ZamzarClient
-        Zamzar::getLogger()->info('(' . $method . ') ' . $endpoint . ' params=' . json_encode($params));
+        if ($this->config['debug']) {
+            Zamzar::getLogger()->info("($method) $endpoint params=" . json_encode($params));
+        }
 
-        // Store local values
         $this->endpoint = $endpoint;
         $this->method = $method;
         $this->params = $params;

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -43,13 +43,6 @@ class ApiResource
         $this->setConfig($config);
 
         $this->setEndPoint($objectId);
-
-        $class = str_replace("Zamzar\\", "", static::class);
-        if ($objectId == '') {
-            Zamzar::getLogger()->info('CreateObj=>' . $class . get_parent_class());
-        } else {
-            Zamzar::getLogger()->info('CreateObj=>' . $class . '=>' . $objectId);
-        }
     }
 
     /**

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -47,9 +47,9 @@ class ApiResource
 
         $class = str_replace("Zamzar\\", "", static::class);
         if ($objectId == '') {
-            Logger::log($this->config, 'CreateObj=>' . $class . get_parent_class());
+            Logger::getLogger()->info('CreateObj=>' . $class . get_parent_class());
         } else {
-            Logger::log($this->config, 'CreateObj=>' . $class . '=>' . $objectId);
+            Logger::getLogger()->info('CreateObj=>' . $class . '=>' . $objectId);
         }
     }
 

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -3,7 +3,6 @@
 namespace Zamzar;
 
 use Zamzar\Util\Core;
-use Zamzar\Util\Logger;
 
 /**
  * ApiResource Class
@@ -47,9 +46,9 @@ class ApiResource
 
         $class = str_replace("Zamzar\\", "", static::class);
         if ($objectId == '') {
-            Logger::getLogger()->info('CreateObj=>' . $class . get_parent_class());
+            Zamzar::getLogger()->info('CreateObj=>' . $class . get_parent_class());
         } else {
-            Logger::getLogger()->info('CreateObj=>' . $class . '=>' . $objectId);
+            Zamzar::getLogger()->info('CreateObj=>' . $class . '=>' . $objectId);
         }
     }
 

--- a/lib/ApiResponse.php
+++ b/lib/ApiResponse.php
@@ -2,8 +2,6 @@
 
 namespace Zamzar;
 
-use Util\Logger;
-
 /**
  * ApiResponse Class
  *

--- a/lib/Exception/ApiErrorException.php
+++ b/lib/Exception/ApiErrorException.php
@@ -25,9 +25,6 @@ class ApiErrorException extends \Exception
         // Expected when extending \Exception
         parent::__construct($message, $code, $previous);
 
-        Zamzar::getLogger()->error(static::class . '. ' . $message);
-
-        // Store the raw array of errors
         if (is_array($errors)) {
             $apiErrors = [];
             foreach ($errors as $error) {

--- a/lib/Exception/ApiErrorException.php
+++ b/lib/Exception/ApiErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Zamzar\Exception;
 
-use Zamzar\Util\Logger;
+use Zamzar\Zamzar;
 
 /**
  * ApiErrorException object which is thrown from the HTTPUtility class based on response codes
@@ -25,7 +25,7 @@ class ApiErrorException extends \Exception
         // Expected when extending \Exception
         parent::__construct($message, $code, $previous);
 
-        Logger::getLogger()->error(static::class . '. ' . $message);
+        Zamzar::getLogger()->error(static::class . '. ' . $message);
 
         // Store the raw array of errors
         if (is_array($errors)) {

--- a/lib/Exception/ApiErrorException.php
+++ b/lib/Exception/ApiErrorException.php
@@ -25,8 +25,7 @@ class ApiErrorException extends \Exception
         // Expected when extending \Exception
         parent::__construct($message, $code, $previous);
 
-        // Log the message
-        Logger::log($config, static::class . '. ' . $message, E_ERROR);
+        Logger::getLogger()->error(static::class . '. ' . $message);
 
         // Store the raw array of errors
         if (is_array($errors)) {

--- a/lib/Util/Core.php
+++ b/lib/Util/Core.php
@@ -2,6 +2,8 @@
 
 namespace Zamzar\Util;
 
+use Zamzar\Zamzar;
+
 /**
  * Core Class
  *
@@ -101,8 +103,8 @@ class Core
 
         // Log the environment, this should happen only once on the initialisation of the ZamzarClient
         if ($environment != '') {
-            Logger::getLogger()->info('Zamzar Client Initialised');
-            Logger::getLogger()->info('Environment=' . ucwords($environment) . ';ApiKey=' . $config['api_key']);
+            Zamzar::getLogger()->info('Zamzar Client Initialised');
+            Zamzar::getLogger()->info('Environment=' . ucwords($environment) . ';ApiKey=' . $config['api_key']);
         }
 
         // Store config array

--- a/lib/Util/Core.php
+++ b/lib/Util/Core.php
@@ -2,8 +2,6 @@
 
 namespace Zamzar\Util;
 
-use Zamzar\Zamzar;
-
 /**
  * Core Class
  *
@@ -101,12 +99,6 @@ class Core
 
         // Validate the config array and throw exceptions if there are any issues
         self::validateConfig($config);
-
-        // Log the environment, this should happen only once on the initialisation of the ZamzarClient
-        if ($environment != '') {
-            Zamzar::getLogger()->info('Zamzar Client Initialised');
-            Zamzar::getLogger()->info('Environment=' . ucwords($environment) . ';ApiKey=' . $config['api_key']);
-        }
 
         // Store config array
         return $config;

--- a/lib/Util/Core.php
+++ b/lib/Util/Core.php
@@ -60,6 +60,7 @@ class Core
             'api_version' => self::API_VERSION,
             'user_agent' => self::USER_AGENT,
             'http_debug' => false,
+            'debug' => false,
         ];
     }
 
@@ -116,9 +117,6 @@ class Core
      */
     private static function validateConfig($config)
     {
-        $msg = null;
-
-        // api_key
         if (!\is_string($config['api_key']) || is_null($config['api_key'])) {
             $msg = 'api_key must be a string with a valid api key';
             throw new \Zamzar\Exception\InvalidArgumentException($msg);
@@ -134,21 +132,23 @@ class Core
             throw new \Zamzar\Exception\InvalidArgumentException($msg);
         }
 
-        // api_base
         if (!strcmp($config['api_base'], self::ZAMZAR_API_PRODUCTION_BASE) == 0 && !strcmp($config['api_base'], self::ZAMZAR_API_SANDBOX_BASE) == 0) {
             $msg = 'api_base must be ' . self::ZAMZAR_API_PRODUCTION_BASE . ' or ' . self::ZAMZAR_API_SANDBOX_BASE;
             throw new \Zamzar\Exception\InvalidArgumentException($msg);
         }
 
-        // api_version
         if (strcmp($config['api_version'], self::API_VERSION) != 0) {
             $msg = 'api_version must be ' . self::API_VERSION;
             throw new \Zamzar\Exception\InvalidArgumentException($msg);
         }
 
-        // user_agent
         if (strcmp($config['user_agent'], self::USER_AGENT) != 0) {
             $msg = 'user_agent must be ' . self::USER_AGENT;
+            throw new \Zamzar\Exception\InvalidArgumentException($msg);
+        }
+
+        if (!is_bool($config['debug'])) {
+            $msg = 'debug must be a boolean';
             throw new \Zamzar\Exception\InvalidArgumentException($msg);
         }
     }

--- a/lib/Util/Core.php
+++ b/lib/Util/Core.php
@@ -47,39 +47,6 @@ class Core
         'Zamzar\Job' => self::JOBS_ENDPOINT,
     ];
 
-
-    /**
-     * The Last Response from any call to the API is stored in the ZamzarClient object
-     * A config array is passed into this function from which a reference to the lastresponse variable is obtained
-     * Only update if it's already set, i.e. if per object instantiation is done, the lastresponse won't be available (because the ZamzarClient is not instantiated if using per-object instantiation)
-     */
-
-    /**
-     * Sets the Logger Object
-     * Note that this is done by reference and stored within ZamzarClient if instantiated
-     */
-    public static function zamzarClientSetLogger(&$config, $logger)
-    {
-        if (array_key_exists("zamzar_client_logger", $config)) {
-            // Get the reference to the logger
-            $zamzarClientLogger = &$config["zamzar_client_logger"];
-            // Set the reference to the supplied logger
-            $zamzarClientLogger = $logger;
-        }
-    }
-
-    /**
-     * Gets the Logger from the supplied Config Array
-     * Note that this done by reference to the the ZamzarClient if instantiated
-     */
-    public static function zamzarClientGetLogger(&$config)
-    {
-        if (array_key_exists("zamzar_client_logger", $config)) {
-            $logger = &$config["zamzar_client_logger"];
-            return $logger;
-        }
-    }
-
     /**
      * Get the Default Config Array
      */
@@ -134,8 +101,8 @@ class Core
 
         // Log the environment, this should happen only once on the initialisation of the ZamzarClient
         if ($environment != '') {
-            Logger::log($config, "Zamzar Client Initialised");
-            Logger::log($config, "Environment=" . ucwords($environment) . ';ApiKey=' . $config['api_key']);
+            Logger::getLogger()->info('Zamzar Client Initialised');
+            Logger::getLogger()->info('Environment=' . ucwords($environment) . ';ApiKey=' . $config['api_key']);
         }
 
         // Store config array

--- a/lib/Util/Logger.php
+++ b/lib/Util/Logger.php
@@ -2,42 +2,29 @@
 
 namespace Zamzar\Util;
 
-/**
- * Logger
- * Outputs log information to an array or a psr3 compatible logger both of which are provided when Zamzarclient is instantiated
- * Supports errors, warnings and notices
- */
 class Logger
 {
     /**
-     * Add an entry to the log
+     * @var null|LoggerInterface The logger to which the library will
+     *   produce messages
      */
-    public static function log(&$config, $message, $messageType = 0)
+    protected static $logger = null;
+
+    /**
+     * @return LoggerInterface the logger to which the library will
+     *   produce messages
+     */
+    public static function getLogger()
     {
-        if (array_key_exists("zamzar_client_logger", $config)) {
-            // Get a reference to the logger (which can be a simple array or a psr-3 compatible logger)
-            $logger = &$config['zamzar_client_logger'];
+        return self::$logger ?? new DefaultLogger();
+    }
 
-            // Output the message and optionally the messagetype
-            $date = date("D M d, Y G:i");
-
-            if (is_array($logger)) {
-                $logger[] = $date . ' ' . $message;
-            } else {
-                // should be a reference to a logger object which uses the standard psr-3 interface
-                // i.e. either an instance of our own DefaultLogger or one provided by user
-                switch ($messageType) {
-                    case 0:
-                        $logger->info($message);
-                        break;
-                    case E_ERROR:
-                        $logger->error($message);
-                        break;
-                    default:
-                        $logger->info($message);
-                        break;
-                }
-            }
-        }
+    /**
+     * @param LoggerInterface $logger The logger to which the library
+     *   will produce messages
+     */
+    public static function setLogger($logger)
+    {
+        self::$logger = $logger;
     }
 }

--- a/lib/Util/LoggerInterface.php
+++ b/lib/Util/LoggerInterface.php
@@ -29,7 +29,7 @@ interface LoggerInterface
      * @param array $context
      * @return void
      */
-    public function error($message, array $context = array());
+    public function error($message, array $context = []);
 
     /**
      * Interesting events.
@@ -40,5 +40,5 @@ interface LoggerInterface
      * @param array $context
      * @return void
      */
-    public function info($message, array $context = array());
+    public function info($message, array $context = []);
 }

--- a/lib/Zamzar.php
+++ b/lib/Zamzar.php
@@ -1,17 +1,19 @@
 <?php
 
-namespace Zamzar\Util;
+namespace Zamzar;
 
-class Logger
+use Zamzar\Util\DefaultLogger;
+
+class Zamzar
 {
     /**
-     * @var null|LoggerInterface The logger to which the library will
+     * @var null|Util\LoggerInterface The logger to which the library will
      *   produce messages
      */
     protected static $logger = null;
 
     /**
-     * @return LoggerInterface the logger to which the library will
+     * @return Util\LoggerInterface the logger to which the library will
      *   produce messages
      */
     public static function getLogger()
@@ -20,7 +22,7 @@ class Logger
     }
 
     /**
-     * @param LoggerInterface $logger The logger to which the library
+     * @param Util\LoggerInterface $logger The logger to which the library
      *   will produce messages
      */
     public static function setLogger($logger)

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -47,21 +47,21 @@ class ZamzarClient extends ApiResource
     }
 
     /**
-     * Setting the logs stores a reference to the logger which is written to in /Util/Logger/Logger using Logger::Log
+     * @param Util\LoggerInterface $logger the logger to which the library
+     *   will produce messages
      */
-    public function setLogger(&$logger)
+    public function setLogger($logger)
     {
-        // set the logger within the config array as a reference to the supplied logger
-        $this->config['zamzar_client_logger'] = &$logger;
-        core::zamzarClientSetLogger($this->config, $logger);
+        Logger::setLogger($logger);
     }
 
     /**
-     * Get the Logger
+     * @return Util\LoggerInterface the logger to which the library will
+     *   produce messages
      */
     public function getLogger()
     {
-        return core::zamzarClientGetLogger($this->config);
+        return Logger::getLogger();
     }
 
     /**

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -3,7 +3,6 @@
 namespace Zamzar;
 
 use Zamzar\Util\Core;
-use Zamzar\Util\Logger;
 
 /**
  *
@@ -52,7 +51,7 @@ class ZamzarClient extends ApiResource
      */
     public function setLogger($logger)
     {
-        Logger::setLogger($logger);
+        Zamzar::setLogger($logger);
     }
 
     /**
@@ -61,7 +60,7 @@ class ZamzarClient extends ApiResource
      */
     public function getLogger()
     {
-        return Logger::getLogger();
+        return Zamzar::getLogger();
     }
 
     /**

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -46,6 +46,7 @@ class ZamzarClient extends ApiResource
     }
 
     /**
+     * @deprecated Use \Zamzar\Zamzar::setLogger() instead.
      * @param Util\LoggerInterface $logger the logger to which the library
      *   will produce messages
      */
@@ -55,6 +56,7 @@ class ZamzarClient extends ApiResource
     }
 
     /**
+     * @deprecated Use \Zamzar\Zamzar::getLogger() instead.
      * @return Util\LoggerInterface the logger to which the library will
      *   produce messages
      */

--- a/readme.md
+++ b/readme.md
@@ -146,11 +146,16 @@ $job = $zamzar
 
 ## Configure a Logger
 
-The library does minimal logging of errors and information. Use either the supplied default logger or a psr-3 compatible logger.
+The library does minimal logging, if the `debug` config option is used. Use either the supplied default logger or a psr-3 compatible logger.
 
 ```php
+$client = new Zamzar\ZamzarClient([
+    'api_key' = '****',
+    'debug' => true,
+]);
+
 // PSR-3 Compatible Logger
-\Zamzar\Zamzar::setLogger($psr3logger);
+\Zamzar\Zamzar::setLogger($psr3Logger);
 
 // Using Monolog
 $logger = new Logger('Zamzar');

--- a/readme.md
+++ b/readme.md
@@ -149,17 +149,13 @@ $job = $zamzar
 The library does minimal logging of errors and information. Use either the supplied default logger or a psr-3 compatible logger.
 
 ```php
-// Default Zamzar Logger (output to the PHP error log)
-$logger = new \Zamzar\Util\DefaultLogger;
-$zamzar->setLogger($logger);
-
 // PSR-3 Compatible Logger
-$zamzar->setLogger($psr3logger);
+\Zamzar\Zamzar::setLogger($psr3logger);
 
 // Using Monolog
 $logger = new Logger('Zamzar');
 $logger->pushHandler(new StreamHandler(__DIR__.'/app.log', Logger::DEBUG));
-$zamzar->setLogger($logger);
+\Zamzar\Zamzar::setLogger($logger);
 ```
 
 ## Contributing

--- a/samples.md
+++ b/samples.md
@@ -51,17 +51,13 @@ $zamzar = new \Zamzar\ZamzarClient([
 The library does minimal logging of errors and information. Use either the supplied default logger or a psr-3 compatible logger.
 
 ```php
-// Default Zamzar Logger (output to the PHP error log)
-$logger = new \Zamzar\Util\DefaultLogger;
-$zamzar->setLogger($logger);
-
 // PSR-3 Compatible Logger
-$zamzar->setLogger($logger);
+\Zamzar\Zamzar::setLogger($logger);
 
 // Using Monolog to output to a custom log file
 $logger = new Logger('Zamzar');
 $logger->pushHandler(new StreamHandler(__DIR__.'/app.log', Logger::DEBUG));
-$zamzar->setLogger($logger);
+\Zamzar\Zamzar::setLogger($logger);
 ```
 
 ### Viewing the Config Array

--- a/samples.md
+++ b/samples.md
@@ -48,11 +48,16 @@ $zamzar = new \Zamzar\ZamzarClient([
 
 ### Configuring a Logger
 
-The library does minimal logging of errors and information. Use either the supplied default logger or a psr-3 compatible logger.
+The library does minimal logging, if the `debug` config option is used. Use either the supplied default logger or a psr-3 compatible logger.
 
 ```php
+$client = new Zamzar\ZamzarClient([
+    'api_key' = '****',
+    'debug' => true,
+]);
+
 // PSR-3 Compatible Logger
-\Zamzar\Zamzar::setLogger($logger);
+\Zamzar\Zamzar::setLogger($psr3Logger);
 
 // Using Monolog to output to a custom log file
 $logger = new Logger('Zamzar');

--- a/tests/ExceptionsTest.php
+++ b/tests/ExceptionsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zamzar;
+namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/FilesTest.php
+++ b/tests/FilesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zamzar;
+namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/FormatsTest.php
+++ b/tests/FormatsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zamzar;
+namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/ImportsTest.php
+++ b/tests/ImportsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zamzar;
+namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zamzar;
+namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Zamzar\Util\LoggerInterface;
+use Zamzar\Zamzar;
+use Zamzar\ZamzarClient;
+
+final class LoggingTest extends TestCase
+{
+    use TestConfig;
+
+    public function testDebugDefaultsToFalse(): void
+    {
+        $client = new ZamzarClient($this->apiKey);
+
+        $logger = $this->createLogger();
+
+        Zamzar::setLogger($logger);
+
+        $client->account->get();
+
+        $this->assertEmpty($logger->log);
+    }
+
+    public function testRequestsAreLogged(): void
+    {
+        $client = new ZamzarClient([
+            'api_key' => $this->apiKey,
+            'debug' => true,
+        ]);
+
+        $logger = $this->createLogger();
+
+        Zamzar::setLogger($logger);
+
+        $client->account->get();
+
+        $this->assertCount(1, $logger->log);
+    }
+
+    public function testLoggerCanBeChanged(): void
+    {
+        $client = new ZamzarClient([
+            'api_key' => $this->apiKey,
+            'debug' => true,
+        ]);
+
+        $logger1 = $this->createLogger();
+        $logger2 = $this->createLogger();
+
+        Zamzar::setLogger($logger1);
+
+        $client->account->get();
+
+        Zamzar::setLogger($logger2);
+
+        $client->account->get();
+
+        $this->assertCount(1, $logger1->log);
+        $this->assertCount(1, $logger2->log);
+    }
+
+    protected function createLogger()
+    {
+        return new class implements LoggerInterface {
+            public $log = [];
+
+            public function error($message, array $context = [])
+            {
+                $this->log[] = $message;
+            }
+
+            public function info($message, array $context = [])
+            {
+                $this->log[] = $message;
+            }
+        };
+    }
+}

--- a/tests/TestConfigTemplate.php
+++ b/tests/TestConfigTemplate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zamzar;
+namespace Tests;
 
 // Rename to TestConfig.php on local machine and specify api key
 trait TestConfig

--- a/tests/ZamzarClientTest.php
+++ b/tests/ZamzarClientTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zamzar;
+namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Simplifies how loggers are used/set, and reduces noisy informational logging:

* Use a static variable to store the logger instance, so it can easily be changed globally.
* Move the logger instance to a new `Zamzar` class.
* Deprecate old `ZamzarClient` get/set logger methods - interact directly with the `Zamzar` class instead.
* Add a `debug` config option that defaults to `false`, and lock informational logging behind it.
* Reduce the 'noise' created by unhelpful logging.
* Add new tests for the logging system.