### PR TITLE
Fix Credits Remaining bugs

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -43,26 +43,41 @@ class Account extends ApiResource
     }
 
     /**
-     * Return the Test Credits Remaining
+     * Return the remaining test credits. This value may be out of date;
+     * consider calling `refresh()` to ensure it's up-to-date.
      */
     public function getTestCreditsRemaining()
     {
+        if (is_null($this->test_credits_remaining)) {
+            $this->get();
+        }
+
         return $this->test_credits_remaining;
     }
 
     /**
-     * Return the Production Credits Remaining
+     * Return the remaining production credits. This value may be out of date;
+     * consider calling `refresh()` to ensure it's up-to-date.
      */
     public function getProductionCreditsRemaining()
     {
+        if (is_null($this->production_credits_remaining)) {
+            $this->get();
+        }
+
         return $this->production_credits_remaining;
     }
 
     /**
-     * Return the Plan
+     * Return information about your plan. This data may be out of date;
+     * consider calling `refresh()` to ensure it's up-to-date.
      */
     public function getPlan()
     {
+        if (is_null($this->plan)) {
+            $this->get();
+        }
+
         return $this->plan;
     }
 }

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -75,19 +75,43 @@ class ZamzarClient extends ApiResource
     }
 
     /**
-     * Get Production Credits Remaining
+     * Get the current amount of production credits remaining from the API
      */
     public function getProductionCreditsRemaining()
     {
-        return $this->getLastResponse()->getProductionCreditsRemaining();
+        return $this->account->get()->getProductionCreditsRemaining();
     }
 
     /**
-     * Get Test Credits Remaining
+     * Get the current amount of test credits remaining from the API
      */
     public function getTestCreditsRemaining()
     {
-        return $this->getLastResponse()->getTestCreditsRemaining();
+        return $this->account->get()->getTestCreditsRemaining();
+    }
+
+    /**
+     * Get the production credits remaining at the time of the last API call.
+     * This may be out of date; consider using `getProductionCreditsRemaining()`
+     * for an up-to-date value.
+     */
+    public function getLastProductionCreditsRemaining()
+    {
+        return $this->hasLastResponse()
+            ? $this->getLastResponse()->getProductionCreditsRemaining()
+            : $this->getProductionCreditsRemaining();
+    }
+
+    /**
+     * Get the test credits remaining at the time of the last API call.
+     * This may be out of date; consider using `getTestCreditsRemaining()`
+     * for an up-to-date value.
+     */
+    public function getLastTestCreditsRemaining()
+    {
+        return $this->hasLastResponse()
+            ? $this->getLastResponse()->getTestCreditsRemaining()
+            : $this->getTestCreditsRemaining();
     }
 
     /**

--- a/samples.md
+++ b/samples.md
@@ -20,7 +20,6 @@ Jump to:
 
 [End-to-End Job Conversion With Exceptions Handling](#End-to-End-Job-Conversion-With-Exceptions-Handling)
 
-
 [Per-Object instantiation](#Per-Object-Instantiation)
 
 [Object Endpoints](#Object-Endpoints)
@@ -72,15 +71,6 @@ When the ZamzarClient is created, a config array is created which is used during
 var_dump($zamzar->getConfig());
 ```
 
-### Viewing the Production and Test Credits Remaining
-
-The credits remaining are returned in the headers of every call to the API and made available through the ZamzarClient.
-
-```php
-echo $zamzar->getProductionCreditsRemaining();
-echo $zamzar->getTestCreditsRemaining();
-```
-
 ### Viewing the Last Response from the API
 
 Viewing the last response from the API can be useful for troubleshooting purposes if the raw responses from the API need to be viewed.
@@ -89,6 +79,25 @@ Viewing the last response from the API can be useful for troubleshooting purpose
 if($zamzar->hasLastResponse()) {
     var_dump($zamzar->getLastResponse());
 }
+```
+
+### Viewing the Production and Test Credits Remaining
+
+The credits remaining are returned in the headers of every call to the API. To retrieve the credits that were available at the time of the last request, either directly access the last response, or call the helper methods on the client:
+
+```php
+$zamzar->getLastResponse()->getProductionCreditsRemaining();
+$zamzar->getLastResponse()->getTestCreditsRemaining();
+
+$zamzar->getLastProductionCreditsRemaining();
+$zamzar->getLastTestCreditsRemaining();
+```
+
+To make a new API call and return the current credits remaining:
+
+```php
+$zamzar->getProductionCreditsRemaining();
+$zamzar->getTestCreditsRemaining();
 ```
 
 ## Account


### PR DESCRIPTION
Fixes a bug whereby trying to access the remaining credits before explicitly making an API results in either an exception, or a `null` response:

* Modifies the behaviour of `ZamzarClient::get***CreditsRemaining()` methods to request the current credits from the API, to ensure the result is up-to-date.
* Adds two new methods (`ZamzarClient::getLast***CreditsRemaining()`), which pull the remaining credits out of the last response (i.e. the previous behaviour). If there is no existing response, calls the appropriate `ZamzarClient::get***CreditsRemaining()` method.
* Modifies the `Account` methods to make an API call if the values are not yet populated.

Tests are passing.