### PR TITLE
Retain support for PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.2.34",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -9,7 +9,7 @@ namespace Zamzar;
  */
 class Account extends ApiResource
 {
-    protected array $propertyMap = [
+    protected $propertyMap = [
         'plan' => Plan::class,
     ];
 

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -98,7 +98,7 @@ class Collection extends ZamzarObject implements \Countable, \ArrayAccess, \Iter
         $params = array_merge(
             ['limit' => $this->paging['limit']],
             ['after' => $this->paging['last']],
-            $params,
+            $params
         );
 
         return $this->all($params);
@@ -116,7 +116,7 @@ class Collection extends ZamzarObject implements \Countable, \ArrayAccess, \Iter
         $params = array_merge(
             ['limit' => $this->paging['limit']],
             ['before' => $this->paging['first']],
-            $params,
+            $params
         );
 
         return $this->all($params);

--- a/lib/Export.php
+++ b/lib/Export.php
@@ -15,7 +15,7 @@ class Export extends ZamzarObject
     public const STATUS_SUCCESSFUL = 'successful';
     public const STATUS_FAILED = 'failed';
 
-    protected array $propertyMap = [
+    protected $propertyMap = [
         'failure' => Failure::class,
     ];
 

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -8,7 +8,7 @@ namespace Zamzar;
  */
 class Format extends ApiResource
 {
-    protected array $propertyMap = [
+    protected $propertyMap = [
         'targets' => [TargetFormat::class],
     ];
 

--- a/lib/HttpClient/GuzzleClient.php
+++ b/lib/HttpClient/GuzzleClient.php
@@ -27,7 +27,7 @@ class GuzzleClient
             return new \Zamzar\ApiResponse(
                 $response->getBody(),
                 $response->getStatusCode(),
-                $response->getHeaders(),
+                $response->getHeaders()
             );
         } else {
             // If we are here, then it's a strange place to be

--- a/lib/Import.php
+++ b/lib/Import.php
@@ -23,7 +23,7 @@ class Import extends ApiResource
     public const STATUS_SUCCESSFUL = 'successful';
     public const STATUS_FAILED = 'failed';
 
-    protected array $propertyMap = [
+    protected $propertyMap = [
         'failure' => Failure::class,
         'file' => File::class,
     ];

--- a/lib/Job.php
+++ b/lib/Job.php
@@ -30,7 +30,7 @@ class Job extends ApiResource
     public const STATUS_FAILED = 'failed';
     public const STATUS_CANCELLED = 'cancelled';
 
-    protected array $propertyMap = [
+    protected $propertyMap = [
         'export' => Export::class,
         'failure' => Failure::class,
         'import' => Import::class,

--- a/lib/Zamzar.php
+++ b/lib/Zamzar.php
@@ -12,7 +12,7 @@ class Zamzar
     ];
 
     public const API_VERSION = 'v1';
-    public const USER_AGENT = 'zamzar-php-v1';
+    public const USER_AGENT = 'zamzar-php-v2';
 
     /** Endpoint constants */
     public const ACCOUNT_ENDPOINT = 'account';

--- a/lib/ZamzarObject.php
+++ b/lib/ZamzarObject.php
@@ -4,9 +4,9 @@ namespace Zamzar;
 
 class ZamzarObject
 {
-    protected array $values = [];
-    protected array $config = [];
-    protected array $propertyMap = [];
+    protected $values = [];
+    protected $config = [];
+    protected $propertyMap = [];
 
     public function __construct($id = null, array $config = [])
     {

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Jump to:
 ## Requirements
 
 - Before you begin, signup for a Zamzar API Account or retrieve your existing API Key from the [Zamzar Developers Homepage](https://developers.zamzar.com/user)
-- PHP 7.2.5 and later.
+- PHP 7.2.34 and later.
 
 ## Installation
 

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -78,7 +78,9 @@ final class JobsTest extends TestCase
 
         $jobs = $this->client->jobs->all(['status' => Job::STATUS_SUCCESSFUL]);
 
-        $this->assertEmpty(array_filter($jobs->data, fn ($job) => $job->status !== Job::STATUS_SUCCESSFUL));
+        $this->assertEmpty(array_filter($jobs->data, function ($job) {
+            return $job->status !== Job::STATUS_SUCCESSFUL;
+        }));
     }
 
     public function testCanPageOnlysuccessfulJobs()


### PR DESCRIPTION
Retains support for PHP 7.2

- Removes type hints from class properties (support was added in PHP 7.4)
- Removes use of arrow functions from tests (support was added in PHP 7.4)
- Fixes parse errors
- Updates package levels in `composer.json` to support for PHP 7.2.34 and above
- Updates the user agent to `zamzar-php-v2`

Tests run successfully