### PR TITLE
Supports options when creating conversion jobs

### DIFF
--- a/lib/HttpClient/GuzzleClient.php
+++ b/lib/HttpClient/GuzzleClient.php
@@ -17,12 +17,7 @@ class GuzzleClient
      */
     public static function request($config, $endpoint, $method = 'GET', $params = [], $hasLocalFile = false, $getFileContent = false)
     {
-        $client = new Client([
-            'headers' => [
-                'Authorization' => 'Bearer ' . $config['api_key'],
-            ],
-        ]);
-
+        $client = $config['transport'] ?? new Client();
         $response = $client->request($method, $endpoint, self::prepareRequest($config, $method, $params, $hasLocalFile));
 
         if (!is_null($response)) {
@@ -42,6 +37,7 @@ class GuzzleClient
         $options = [
             'debug' => $config['http_debug'],
             'headers' => [
+                'Authorization' => 'Bearer ' . $config['api_key'],
                 'User-Agent' => $config['user_agent'],
             ],
             'http_errors' => false,

--- a/lib/Service/JobService.php
+++ b/lib/Service/JobService.php
@@ -9,6 +9,11 @@ class JobService extends AbstractService
 {
     public function create($params)
     {
+        // if params['options'] is an array, JSON encode it
+        if (array_key_exists('options', $params) && is_array($params['options'])) {
+            $params['options'] = json_encode($params['options']);
+        }
+
         $response = $this->client->request('POST', Job::classUrl(), $params);
 
         return Job::constructFrom($response->getBody(), $this->client->getConfig());

--- a/samples.md
+++ b/samples.md
@@ -64,6 +64,24 @@ $logger->pushHandler(new StreamHandler(__DIR__.'/app.log', Logger::DEBUG));
 \Zamzar\Zamzar::setLogger($logger);
 ```
 
+### Customising the Guzzle HTTP Client
+
+This library uses Guzzle as the HTTP client. The default client can be customised by passing in a custom Guzzle client instance.
+
+```php
+// create a custom Guzzle client
+$guzzle = new \GuzzleHttp\Client([
+    'timeout' => 10,
+    'connect_timeout' => 5,
+]);
+
+// pass the custom Guzzle client to the ZamzarClient
+$zamzar = new \Zamzar\ZamzarClient([
+    'api_key' => '****',
+    'transport' => $guzzle
+]);
+```
+
 ### Viewing the Config Array
 
 When the ZamzarClient is created, a config array is created which is used during subsequent API calls.

--- a/samples.md
+++ b/samples.md
@@ -51,7 +51,7 @@ The library does minimal logging, if the `debug` config option is used. Use eith
 
 ```php
 $client = new Zamzar\ZamzarClient([
-    'api_key' = '****',
+    'api_key' => '****',
     'debug' => true,
 ]);
 

--- a/samples.md
+++ b/samples.md
@@ -510,6 +510,20 @@ $job = $zamzar->jobs->create([
 ]);
 ```
 
+### Specifying conversion options
+
+Conversion options can be specified for certain target formats. For example, to specify a different voice for a text-to-speech conversion:
+
+```php
+$job = $zamzar->jobs->create([
+    'source_file' => 'path/to/local/file.txt',
+    'target_format' => 'mp3',
+    'options' => [
+        'voice' => 'en.female'
+    ]
+]);
+```
+
 ### Waiting for a job to complete
 
 The <code>waitForCompletion()</code> method is used to wait for a job to complete, which will poll the job at exponentially larger intervals upto a maximum timeout.


### PR DESCRIPTION
- Adds support for an `options` array to `$jobs->create()`, allowing users to override conversion customisations.
- Allows the underlying Guzzle HTTP client to be customised via a new `$config['transport']` option