### PR TITLE
Fixes memory exhaustion when downloading large files

### DIFF
--- a/lib/ApiResponse.php
+++ b/lib/ApiResponse.php
@@ -14,22 +14,36 @@ class ApiResponse
     private $body;
     private $code;
     private $headers;
+    private $parsedBody;
 
     public function __construct($body, $code, $headers)
     {
-        $this->body = json_decode($body, true);
+        $this->body = $body;
         $this->code = $code;
         $this->headers = $headers;
     }
 
+    /**
+     * Get the body of the response. Returns an array if the body is valid JSON.
+     *
+     * Note that this method will attempt to convert the entire request body to a string in memory. Callers must
+     * ensure that the content length of the response is not so large that it would cause memory exhaustion. Use
+     * getBodyRaw() to get the raw body without loading its entire contents into memory.
+     *
+     * @return array|null
+     */
     public function getBody()
     {
-        return $this->body;
+        if (is_null($this->parsedBody)) {
+            $this->parsedBody = json_decode($this->body, true);
+        }
+
+        return $this->parsedBody;
     }
 
     public function getBodyRaw()
     {
-        return json_encode($this->body);
+        return $this->body;
     }
 
     public function getCode()

--- a/tests/FilesTest.php
+++ b/tests/FilesTest.php
@@ -10,6 +10,8 @@ final class FilesTest extends TestCase
 {
     use WithClient;
 
+    private const MOCK_LARGE_FILE_ID = 0;
+
     public function testFilesAreListable(): void
     {
         $files = $this->client()->files->all(['limit' => 1]);
@@ -33,11 +35,28 @@ final class FilesTest extends TestCase
         $this->assertGreaterThan(0, $file->id);
     }
 
+    public function testLargeFileCanBeUploaded(): void
+    {
+        // Create a file that's larger than the default PHP memory limit (128MB)
+        $path = $this->createTempFile(256 * 1024); // 256MB
+        $file = $this->client()->files->create([
+            'name' => $path
+        ]);
+        $this->assertGreaterThan(0, $file->id);
+    }
+
     public function testFileCanBeDownloaded(): void
     {
         $file = $this->client()->files->create([
             'name' => __DIR__ . '/files/source/test.pdf'
         ]);
+        $file->download(__DIR__ . '/files/target/');
+        $this->assertEquals(file_exists(__DIR__ . '/files/target/' . $file->name), true);
+    }
+
+    public function testLargeFileCanBeDownloaded(): void
+    {
+        $file = $this->client()->files->get(self::MOCK_LARGE_FILE_ID);
         $file->download(__DIR__ . '/files/target/');
         $this->assertEquals(file_exists(__DIR__ . '/files/target/' . $file->name), true);
     }
@@ -72,5 +91,36 @@ final class FilesTest extends TestCase
         ])->waitForCompletion();
 
         $this->assertGreaterThan(0, $job->target_files[0]->size);
+    }
+
+    private function createTempFile($sizeInKb) {
+        // Generate a temporary file name
+        $tempFile = tempnam(sys_get_temp_dir(), 'temp_');
+
+        // Open the file for writing
+        $handle = fopen($tempFile, 'w');
+
+        // Write to the file to make it the desired size (in KB)
+        // Each '*' character is one byte, and 1024 bytes are 1KB
+        $bytes = $sizeInKb * 1024;
+
+        // Write in chunks to avoid excessive memory usage
+        $chunkSize = 1024; // 1KB chunks
+        $chunks = intval($bytes / $chunkSize);
+        $remainder = $bytes % $chunkSize;
+
+        for ($i = 0; $i < $chunks; $i++) {
+            fwrite($handle, str_repeat('*', $chunkSize));
+        }
+
+        if ($remainder > 0) {
+            fwrite($handle, str_repeat('*', $remainder));
+        }
+
+        // Close the file handle
+        fclose($handle);
+
+        // Return the path to the temporary file
+        return $tempFile;
     }
 }


### PR DESCRIPTION
Avoids eagerly attempting to parse all HTTP responses as JSON, which causes Guzzle to load the entire response body into memory. The eager parsing can cause memory exhaustion when the response contains the binary contents of a file.