### PR TITLE
Prefers Composer installations in README

### DIFF
--- a/init.php
+++ b/init.php
@@ -1,5 +1,11 @@
 <?php
 
+// If you're not using Composer, require_once this file to load the Zamzar PHP SDK
+// You'll need to ensure that you've also:
+//   - Loaded Guzzle and its dependencies (https://docs.guzzlephp.org/en/stable/overview.html)
+//   - Loaded the PHP JSON extension (https://secure.php.net/manual/en/book.json.php)
+// See ./composer.json for the required versions of these dependencies
+
 // Utilities
 require __DIR__ . '/lib/Util/LoggerInterface.php';
 require __DIR__ . '/lib/Util/DefaultLogger.php';

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,6 @@ Jump to:
 
 - [Requirements](#requirements)
 - [Installation](#installation)
-- [Dependencies](#dependencies)
 - [Initialise the Zamzar Client](#initialise-the-zamzar-client)
 - [Test the Connection](#test-the-connection)
 - [Typical Usage](#typical-usage)
@@ -43,21 +42,6 @@ To use the bindings, use Composer's [autoload](https://getcomposer.org/doc/01-ba
 ```php
 require_once('vendor/autoload.php');
 ```
-
-If you do not wish to use Composer, you can download the [latest release](https://github.com/zamzar/zamzar-php/releases). Then, to use the bindings, include the `init.php` file.
-
-```php
-require_once('/path/to/zamzar-php/init.php');
-```
-
-## Dependencies
-
-The bindings require the following extensions in order to work properly:
-
--   [`Guzzle HTTP Client`](https://docs.guzzlephp.org/en/stable/overview.html)
--   [`JSON Extension`](https://secure.php.net/manual/en/book.json.php)
-
-If you use Composer, these dependencies should be handled automatically. If you install manually, you'll want to make sure that these extensions are available.
 
 ## Initialise the Zamzar Client
 


### PR DESCRIPTION
Since we first published this library, Guzzle has adopted a less monolithic approach. It now ships with a number of dependencies, and there are a handful of transitive dependences as well. As such, manual installation is now quite cumbersome.

In this PR, we nudge users towards using the `composer` package manage to manage installation.

We continue to provide the `init.php` script so as not to break backwards-compatibility, but we may choose to remove it in a future major version of the SDK.

For users who would prefer not to use Composer, we offer:

* [API docs](https://developers.zamzar.com/docs) - which provide the reference material needed to write custom API integration code (e.g., using PHP's `ext-curl` directly).
* an [OpenAPI Spec](https://github.com/zamzar/zamzar-spec) - for generating API integration code either via off-the-shelf or custom templates