### PR TITLE
Adds a recommended Guzzle transport

### DIFF
--- a/lib/HttpClient/GuzzleClient.php
+++ b/lib/HttpClient/GuzzleClient.php
@@ -3,6 +3,11 @@
 namespace Zamzar\HttpClient;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware as GuzzleMiddleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 
 /**
@@ -12,13 +17,59 @@ use GuzzleHttp\Psr7\Utils;
  */
 class GuzzleClient
 {
+    public static function recommendedTransport(): Client
+    {
+        // All timeouts are in seconds
+        return new Client([
+            'connect_timeout' => 15,
+            'read_timeout' => 30,
+            'timeout' => 60,
+            'handler' => self::recommendedStack(),
+        ]);
+    }
+
+    public static function recommendedStack(callable $handler = null, int $maxRetries = 5): HandlerStack
+    {
+        $stack = HandlerStack::create($handler);
+        $stack->remove('http_errors'); // Disable default HTTP error handling to allow custom retry logic
+        $stack->push(static::backoffRetryServerErrorsMiddleware($maxRetries), 'zamzar_backoff_retry_server_errors');
+        return $stack;
+    }
+
+    protected static function backoffRetryServerErrorsMiddleware(int $maxRetries = 5): callable
+    {
+        return GuzzleMiddleware::retry(function (
+            $retries,
+            Request $request,
+            Response $response = null,
+            RequestException $exception = null
+        ) use ($maxRetries) {
+            // Limit the number of retries
+            if ($retries >= $maxRetries) {
+                return false;
+            }
+
+            return $response && in_array($response->getStatusCode(), [502, 503, 504]);
+        });
+    }
+
     /**
      * A single request method accommodates all requests to the API
      */
-    public static function request($config, $endpoint, $method = 'GET', $params = [], $hasLocalFile = false, $getFileContent = false)
-    {
+    public static function request(
+        $config,
+        $endpoint,
+        $method = 'GET',
+        $params = [],
+        $hasLocalFile = false,
+        $getFileContent = false
+    ) {
         $client = $config['transport'] ?? new Client();
-        $response = $client->request($method, $endpoint, self::prepareRequest($config, $method, $params, $hasLocalFile));
+        $response = $client->request(
+            $method,
+            $endpoint,
+            self::prepareRequest($config, $method, $params, $hasLocalFile)
+        );
 
         if (!is_null($response)) {
             return new \Zamzar\ApiResponse(
@@ -28,7 +79,12 @@ class GuzzleClient
             );
         } else {
             // If we are here, then it's a strange place to be
-            throw new \Zamzar\Exception\UnknownApiErrorException($config, $endpoint, null, 'An unexpected error has occurred. No response received');
+            throw new \Zamzar\Exception\UnknownApiErrorException(
+                $config,
+                $endpoint,
+                null,
+                'An unexpected error has occurred. No response received'
+            );
         }
     }
 
@@ -57,7 +113,10 @@ class GuzzleClient
             foreach ($params as $key => $value) {
                 $options['multipart'][] = [
                     'name' => $key,
-                    'contents' => ($hasFile && ($key === 'source_file' || $key === 'content')) ? Utils::tryFopen($value, 'r') : $value,
+                    'contents' => ($hasFile && ($key === 'source_file' || $key === 'content')) ? Utils::tryFopen(
+                        $value,
+                        'r'
+                    ) : $value,
                 ];
             }
         } else {

--- a/lib/ZamzarClient.php
+++ b/lib/ZamzarClient.php
@@ -2,6 +2,8 @@
 
 namespace Zamzar;
 
+use GuzzleHttp\Client;
+use Zamzar\HttpClient\GuzzleClient;
 use Zamzar\Service\AccountService;
 use Zamzar\Service\FileService;
 use Zamzar\Service\FormatService;
@@ -28,9 +30,23 @@ class ZamzarClient extends BaseZamzarClient
     private $services = [];
 
     /**
-     * @deprecated Use \Zamzar\Zamzar::setLogger() instead.
+     * Returns a new instance of a Guzzle client that can be used as transport. This client will automatically:
+     *  - time out long-running requests
+     *  - retry requests that fail or time out
+     *
+     * This will become the default transport in a future version of the library.
+     *
+     * @return Client
+     */
+    public static function recommendedTransport(): Client
+    {
+        return GuzzleClient::recommendedTransport();
+    }
+
+    /**
      * @param Util\LoggerInterface $logger the logger to which the library
      *   will produce messages
+     * @deprecated Use \Zamzar\Zamzar::setLogger() instead.
      */
     public function setLogger($logger)
     {
@@ -38,9 +54,9 @@ class ZamzarClient extends BaseZamzarClient
     }
 
     /**
-     * @deprecated Use \Zamzar\Zamzar::getLogger() instead.
      * @return Util\LoggerInterface the logger to which the library will
      *   produce messages
+     * @deprecated Use \Zamzar\Zamzar::getLogger() instead.
      */
     public function getLogger()
     {

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,9 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/zamzar/zamzar-php.svg?style=flat)](https://packagist.org/packages/zamzar/zamzar-php)
 [![Apache 2 License](https://img.shields.io/packagist/l/zamzar/zamzar-php.svg?style=flat)](https://github.com/zamzar/zamzar-php/blob/main/LICENSE)
 
-Easy to use PHP file conversion API with support for 1,100+ file conversions - convert documents, audio, images, video, eBooks and more. Use `zamzar-php` to convert files between different formats as part of your PHP application with the [Zamzar file conversion API](https://developers.zamzar.com). Common use cases include:
+Easy to use PHP file conversion API with support for 1,100+ file conversions - convert documents, audio, images, video,
+eBooks and more. Use `zamzar-php` to convert files between different formats as part of your PHP application with
+the [Zamzar file conversion API](https://developers.zamzar.com). Common use cases include:
 
 * Convert Microsoft Word (DOCX, DOC) to PDF
 * Extract text from PDF files
@@ -12,7 +14,6 @@ Easy to use PHP file conversion API with support for 1,100+ file conversions - c
 * Archive email (MSG files) to PDF
 
 This is the official PHP SDK for the [Zamzar file conversion API](https://developers.zamzar.com).
-
 
 Jump to:
 
@@ -26,7 +27,8 @@ Jump to:
 
 ## Requirements
 
-- Before you begin, signup for a Zamzar API Account or retrieve your existing API Key from the [Zamzar Developers Homepage](https://developers.zamzar.com/user)
+- Before you begin, signup for a Zamzar API Account or retrieve your existing API Key from
+  the [Zamzar Developers Homepage](https://developers.zamzar.com/user)
 - PHP 7.2.34 and later.
 
 ## Installation
@@ -45,12 +47,15 @@ require_once('vendor/autoload.php');
 
 ## Initialise the Zamzar Client
 
-To initialise the client, declare a new ZamzarClient which accepts a string or config array:
+To initialise the client, declare a new ZamzarClient:
 
 ```php
 
 // Connect to the Production API using an API Key
-$zamzar = new \Zamzar\ZamzarClient('apikey');
+$zamzar = new \Zamzar\ZamzarClient([
+    'api_key' => 'apiKey',
+    'transport' => \Zamzar\ZamzarClient::recommendedTransport()
+]);
 ```
 
 To specify whether the client using the Production or Test API, use a Config array:
@@ -60,21 +65,24 @@ To specify whether the client using the Production or Test API, use a Config arr
 // Use the Production API
 $zamzar = new \Zamzar\ZamzarClient([
     'api_key' => 'apiKey',
-    'environment' => 'production'
+    'environment' => 'production',
+    'transport' => \Zamzar\ZamzarClient::recommendedTransport()
 ]);
 
 
 // Use the Sandbox API
 $zamzar = new \Zamzar\ZamzarClient([
     'api_key' => 'apiKey',
-    'environment' => 'sandbox'
+    'environment' => 'sandbox',
+    'transport' => \Zamzar\ZamzarClient::recommendedTransport()
 ]);
 
 ```
 
 ## Test the Connection
 
-To confirm your credentials are correct, test the connection to the API which will return a welcome message and confirm which API you are using (Production or Test).
+To confirm your credentials are correct, test the connection to the API which will return a welcome message and confirm
+which API you are using (Production or Test).
 
 ```php
 
@@ -84,7 +92,8 @@ echo $zamzar->testConnection();
 
 ## Typical Usage
 
-The most common requirement is to submit a job to convert a file, wait for the job to complete, download the converted files and delete the files on  Zamzar servers.
+The most common requirement is to submit a job to convert a file, wait for the job to complete, download the converted
+files and delete the files on Zamzar servers.
 
 ```php
 // Submit the file
@@ -103,7 +112,8 @@ $job->downloadTargetFiles('path/to/folder/');
 $job->deleteAllFiles();
 ```
 
-The above use case might be applied when other things are happening in between each step, but if not, and you want to chain the whole thing together:
+The above use case might be applied when other things are happening in between each step, but if not, and you want to
+chain the whole thing together:
 
 ```php
 // Do the whole thing together
@@ -118,7 +128,8 @@ $job = $zamzar->jobs->create([
 
 ## Configure a Logger
 
-The library does minimal logging, if the `debug` config option is used. Use either the supplied default logger or a psr-3 compatible logger.
+The library does minimal logging, if the `debug` config option is used. Use either the supplied default logger or a
+psr-3 compatible logger.
 
 ```php
 $client = new Zamzar\ZamzarClient([
@@ -141,4 +152,5 @@ $logger->pushHandler(new StreamHandler(__DIR__.'/app.log', Logger::DEBUG));
 
 [Exceptions Handling](exceptions.md) - Learn more about API Error Codes.
 
-[Developer Docs](https://developers.zamzar.com/docs) - For more information about API operations, parameters, and responses. Use this if you need additional context on all areas of functionality.
+[Developer Docs](https://developers.zamzar.com/docs) - For more information about API operations, parameters, and
+responses. Use this if you need additional context on all areas of functionality.

--- a/samples.md
+++ b/samples.md
@@ -1,6 +1,8 @@
 # Code Samples
 
-The following code samples demonstrate the features of the library. Most samples can be copy/pasted into your own environment and should work 'out of the box' as long as you have a valid API key. Some samples which may not work will relate to local folder and file locations, and connected services such as Amazon S3 storage.
+The following code samples demonstrate the features of the library. Most samples can be copy/pasted into your own
+environment and should work 'out of the box' as long as you have a valid API key. Some samples which may not work will
+relate to local folder and file locations, and connected services such as Amazon S3 storage.
 
 Jump to:
 
@@ -32,7 +34,10 @@ Initialising a ZamzarClient is the starting point for any calls to be made to th
 
 ```php
 // supply an api key
-$zamzar = new \Zamzar\ZamzarClient('apikey');
+$zamzar = new \Zamzar\ZamzarClient([
+    'api_key' => 'apikey',
+    'transport' => \Zamzar\ZamzarClient::recommendedTransport()
+]);
 ```
 
 ### Use the Sandbox Environment
@@ -42,17 +47,20 @@ $zamzar = new \Zamzar\ZamzarClient('apikey');
 $zamzar = new \Zamzar\ZamzarClient([
     'api_key' => 'apikey',
     'environment' => 'sandbox'
+    'transport' => \Zamzar\ZamzarClient::recommendedTransport()
 ]);
 ```
 
 ### Configuring a Logger
 
-The library does minimal logging, if the `debug` config option is used. Use either the supplied default logger or a psr-3 compatible logger.
+The library does minimal logging, if the `debug` config option is used. Use either the supplied default logger or a
+psr-3 compatible logger.
 
 ```php
 $client = new Zamzar\ZamzarClient([
     'api_key' => '****',
     'debug' => true,
+    'transport' => \Zamzar\ZamzarClient::recommendedTransport()
 ]);
 
 // PSR-3 Compatible Logger
@@ -66,7 +74,8 @@ $logger->pushHandler(new StreamHandler(__DIR__.'/app.log', Logger::DEBUG));
 
 ### Customising the Guzzle HTTP Client
 
-This library uses Guzzle as the HTTP client. The default client can be customised by passing in a custom Guzzle client instance.
+This library uses Guzzle as the HTTP client. The default client can be customised by passing in a custom Guzzle client
+instance.
 
 ```php
 // create a custom Guzzle client
@@ -82,6 +91,21 @@ $zamzar = new \Zamzar\ZamzarClient([
 ]);
 ```
 
+Unless you need to customise the Guzzle client, it is recommended to use the `recommendedTransport()` method which
+provides a Guzzle client with sensible defaults for the Zamzar API.
+
+```php
+$zamzar = new \Zamzar\ZamzarClient([
+    'api_key' => '****',
+    'transport' => \Zamzar\ZamzarClient::recommendedTransport()
+]);
+```
+
+By default, the recommended transport will automatically:
+
+* time out long-running requests
+* retry requests that fail or time out
+
 ### Viewing the Config Array
 
 When the ZamzarClient is created, a config array is created which is used during subsequent API calls.
@@ -92,7 +116,8 @@ var_dump($zamzar->getConfig());
 
 ### Viewing the Last Response from the API
 
-Viewing the last response from the API can be useful for troubleshooting purposes if the raw responses from the API need to be viewed.
+Viewing the last response from the API can be useful for troubleshooting purposes if the raw responses from the API need
+to be viewed.
 
 ```php
 if($zamzar->hasLastResponse()) {
@@ -102,7 +127,8 @@ if($zamzar->hasLastResponse()) {
 
 ### Viewing the Production and Test Credits Remaining
 
-The credits remaining are returned in the headers of every call to the API. To retrieve the credits that were available at the time of the last request, either directly access the last response, or call the helper methods on the client:
+The credits remaining are returned in the headers of every call to the API. To retrieve the credits that were available
+at the time of the last request, either directly access the last response, or call the helper methods on the client:
 
 ```php
 $zamzar->$lastResponse->getProductionCreditsRemaining();
@@ -141,7 +167,7 @@ echo $plan->maximum_file_size;
 
 ## Files
 
-File related objects are used to retrieve a list of files, upload, download and delete files. 
+File related objects are used to retrieve a list of files, upload, download and delete files.
 
 ### Uploading a File
 
@@ -194,7 +220,6 @@ $job = $file->convert([
     'target_format' => 'xxx'
 ]);
 ```
-
 
 ### Retrieving a file
 
@@ -311,7 +336,6 @@ $formats = $formats->previousPage();
 
 Import related objects are used to retrieve information about imports and to start import operations.
 
-
 ### Starting an Import
 
 The <code>create</code> operator is performed on the Imports object, which creates and returns an Import object.
@@ -326,7 +350,8 @@ echo $import->id;
 
 ### Checking on the status of an Import
 
-After an import has started, the status can be checked to determine one of four status values: <code>initialising</code>, <code>downloading</code>, <code>successful</code> or <code>failed</code>. 
+After an import has started, the status can be checked to determine one of four status values: <code>
+initialising</code>, <code>downloading</code>, <code>successful</code> or <code>failed</code>.
 
 ```php
 // start an import
@@ -357,7 +382,8 @@ if ($import->isStatusFailed()) {
 }
 ```
 
-Instead of checking for each status value, the <code>hasCompleted()</code> method can be used to check if an import has completed or not.
+Instead of checking for each status value, the <code>hasCompleted()</code> method can be used to check if an import has
+completed or not.
 
 ```php
 if ($import->hasCompleted()) {
@@ -377,7 +403,8 @@ $import->waitForCompletion();
 
 ### Checking why an import failed
 
-If an import has failed it will have a <code>status</code> of <code>failed</code> and include a <code>failure</code> object.
+If an import has failed it will have a <code>status</code> of <code>failed</code> and include a <code>failure</code>
+object.
 
 ```php
 if ($import->isStatusFailed()) {
@@ -450,8 +477,8 @@ $imports = $imports->previousPage();
 
 ## Jobs
 
-Job related objects are used to retrieve information about jobs and to submit conversion jobs followed by downloading and deleting converted files.
-
+Job related objects are used to retrieve information about jobs and to submit conversion jobs followed by downloading
+and deleting converted files.
 
 ### Starting a Job
 
@@ -487,7 +514,8 @@ echo $job->id;
 
 ### Overriding the Source Format
 
-The source format can be overridden if the <code>source_file</code> does not have a format within the filename for example:
+The source format can be overridden if the <code>source_file</code> does not have a format within the filename for
+example:
 
 ```php
 $job = $zamzar->jobs->create([
@@ -499,7 +527,8 @@ $job = $zamzar->jobs->create([
 
 ### Exporting converted files to a remote server
 
-An <code>export_url</code> can be provided to instruct the conversion process to export files to a remote server once the job has completed:
+An <code>export_url</code> can be provided to instruct the conversion process to export files to a remote server once
+the job has completed:
 
 ```php
 $job = $zamzar->jobs->create([
@@ -512,7 +541,8 @@ $job = $zamzar->jobs->create([
 
 ### Specifying conversion options
 
-Conversion options can be specified for certain target formats. For example, to specify a different voice for a text-to-speech conversion:
+Conversion options can be specified for certain target formats. For example, to specify a different voice for a
+text-to-speech conversion:
 
 ```php
 $job = $zamzar->jobs->create([
@@ -526,7 +556,8 @@ $job = $zamzar->jobs->create([
 
 ### Waiting for a job to complete
 
-The <code>waitForCompletion()</code> method is used to wait for a job to complete, which will poll the job at exponentially larger intervals upto a maximum timeout.
+The <code>waitForCompletion()</code> method is used to wait for a job to complete, which will poll the job at
+exponentially larger intervals upto a maximum timeout.
 
 ```php
 // default timeout of 60 seconds
@@ -538,7 +569,8 @@ $job = $job->waitForCompletion(120);
 
 ### Check on the status of a Job
 
-After an job has started, the status can be checked to determine one of five status values: <code>initialising</code>, <code>converting</code>, <code>cancelled</code>, <code>successful</code> or <code>failed</code>. 
+After an job has started, the status can be checked to determine one of five status values: <code>
+initialising</code>, <code>converting</code>, <code>cancelled</code>, <code>successful</code> or <code>failed</code>.
 
 ```php
 // start a job
@@ -577,7 +609,8 @@ if ($job->isStatusFailed()) {
 }
 ```
 
-Instead of checking for each status value, the <code>hasCompleted()</code> method can be used to check if a job has completed successfully or not.
+Instead of checking for each status value, the <code>hasCompleted()</code> method can be used to check if a job has
+completed successfully or not.
 
 ```php
 if ($job->hasCompleted()) {
@@ -697,7 +730,9 @@ $jobs = $jobs->previousPage();
 
 ## Exceptions
 
-All of the above examples do not use exceptions handling for brevity. In real-world scenarious where the SDK is being used to support production processes, the failure of any part of the following request might cause an issue with tracking, reporting or wasting conversion credits if jobs have to be resubmitted. 
+All of the above examples do not use exceptions handling for brevity. In real-world scenarious where the SDK is being
+used to support production processes, the failure of any part of the following request might cause an issue with
+tracking, reporting or wasting conversion credits if jobs have to be resubmitted.
 
 ```php
 //start, wait, download, delete - but don't give the job any time to complete
@@ -707,7 +742,8 @@ $job = $zamzar->jobs->create([
 ])->waitForCompletion(0);
 ```
 
-The above example fails immediately, an uncaught error is reported and the process aborted. Using exception handling provides an opportunity to handle the error.
+The above example fails immediately, an uncaught error is reported and the process aborted. Using exception handling
+provides an opportunity to handle the error.
 
 ```php
 try {
@@ -722,10 +758,12 @@ try {
 
 [Read more about exceptions](exceptions.md) to find out the custom exceptions which can be caught.
 
-
 ## End-to-End Job Conversion With Exceptions Handling
 
-In a production batch processing scenario, it might be preferable to break the above job submission examples into their component parts, so that context and continuity is not lost if an exception is thrown in between what is four discrete operations - submit, wait, download, delete - whilst giving the opportunity to retry operations and audit events at a more granular level.
+In a production batch processing scenario, it might be preferable to break the above job submission examples into their
+component parts, so that context and continuity is not lost if an exception is thrown in between what is four discrete
+operations - submit, wait, download, delete - whilst giving the opportunity to retry operations and audit events at a
+more granular level.
 
 ```php
 /**
@@ -793,7 +831,8 @@ if($proceed) {
 
 ## Object Endpoints
 
-Each object stores its own endpoint, which is not an essential part of using the library, but might be useful for troubleshooting.
+Each object stores its own endpoint, which is not an essential part of using the library, but might be useful for
+troubleshooting.
 
 ```php
 foreach($jobs as $job) {

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Zamzar\HttpClient\GuzzleClient;
+
+final class GuzzleClientTest extends TestCase
+{
+    public function testRetries()
+    {
+        $mock = new MockHandler([
+            new Response(504),
+            new Response(504),
+            new Response(200, [], 'OK')
+        ]);
+
+        $historyContainer = [];
+        $history = Middleware::history($historyContainer);
+
+        $stack = GuzzleClient::recommendedStack($mock);
+        $stack->push($history);
+
+        $client = new Client(['handler' => $stack]);
+
+        $response = $client->get('/some-endpoint');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(3, $historyContainer, "Should have tried twice before success");
+    }
+
+    public function testRetriesDoNotExceedMaximum()
+    {
+        $mock = new MockHandler([
+            new Response(504),
+            new Response(504),
+            new Response(200, [], 'OK')
+        ]);
+
+        $historyContainer = [];
+        $history = Middleware::history($historyContainer);
+
+        $stack = GuzzleClient::recommendedStack($mock, 1);
+        $stack->push($history);
+
+        $client = new Client(['handler' => $stack]);
+
+        $response = $client->get('/some-endpoint');
+
+        $this->assertEquals(504, $response->getStatusCode());
+        $this->assertCount(2, $historyContainer, "Should have tried exactly twice");
+    }
+
+    public function testRetriesAreUnnecessaryWhenResponseIsOk()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], 'OK')
+        ]);
+
+        $historyContainer = [];
+        $history = Middleware::history($historyContainer);
+
+        $stack = GuzzleClient::recommendedStack($mock);
+        $stack->push($history);
+
+        $client = new Client(['handler' => $stack]);
+
+        $response = $client->get('/some-endpoint');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(1, $historyContainer, "Should have tried exactly once");
+    }
+}

--- a/tests/WithClient.php
+++ b/tests/WithClient.php
@@ -8,7 +8,8 @@ use Zamzar\ZamzarClient;
 trait WithClient
 {
     /** @before */
-    protected function resetMock() {
+    protected function resetMock()
+    {
         // Construct the URL for to reset the mock
         // See: https://github.com/zamzar/zamzar-mock/blob/main/README.md
         $parts = parse_url($this->baseUrl());
@@ -23,6 +24,7 @@ trait WithClient
         $configDefaults = [
             'api_key' => $this->apiKey(),
             'base_url' => $this->baseUrl(),
+            'transport' => ZamzarClient::recommendedTransport(),
         ];
 
         $config = array_merge($configDefaults, $configOverrides);


### PR DESCRIPTION
Adds a recommended Guzzle transport that:

* time out long-running requests
* retry requests that fail or time out

To avoid a breaking change in a minor release, this transport is advisory and opt-in for now. It will become the default transport in a future major release of the SDK.