### PR TITLE
Widens acceptable type in retry middleware

### DIFF
--- a/lib/HttpClient/GuzzleClient.php
+++ b/lib/HttpClient/GuzzleClient.php
@@ -2,8 +2,8 @@
 
 namespace Zamzar\HttpClient;
 
+use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware as GuzzleMiddleware;
 use GuzzleHttp\Psr7\Request;
@@ -42,7 +42,7 @@ class GuzzleClient
             $retries,
             Request $request,
             Response $response = null,
-            RequestException $exception = null
+            Exception $exception = null
         ) use ($maxRetries) {
             // Limit the number of retries
             if ($retries >= $maxRetries) {


### PR DESCRIPTION
The [Guzzle source](https://github.com/guzzle/guzzle/blob/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77/src/RetryMiddleware.php#L35) doesn't restrict the type of the `exception` that is passed to the decider in a retry middleware implementation, so we shouldn't either.